### PR TITLE
add-init! should ignore nodejs builds now

### DIFF
--- a/src/adzerk/boot_cljs_repl.clj
+++ b/src/adzerk/boot_cljs_repl.clj
@@ -103,14 +103,15 @@
 
 (defn- add-init!
   [in-file out-file]
-  (let [ns 'adzerk.boot-cljs-repl]
-    (util/info "Adding :require %s to %s...\n" ns (.getName in-file))
-    (-> in-file
-        slurp
-        read-string
-        (update-in [:require] conj ns)
-        pr-str
-        ((partial spit out-file)))))
+  (let [ns 'adzerk.boot-cljs-repl
+        spec (-> in-file slurp read-string)]
+    (when (not= :nodejs (-> spec :compiler-options :target))
+      (util/info "Adding :require %s to %s...\n" ns (.getName in-file))
+      (io/make-parents out-file)
+      (-> spec
+          (update-in [:require] conj ns)
+          pr-str
+          ((partial spit out-file))))))
 
 (b/deftask cljs-repl
   "Start a ClojureScript REPL server.


### PR DESCRIPTION
With code stolen from https://github.com/adzerk-oss/boot-reload/blob/master/src/adzerk/boot_reload.clj#L47