### PR TITLE
Adds ws-host and secure options to allow proxing cljs-repl

### DIFF
--- a/src/adzerk/boot_cljs_repl.clj
+++ b/src/adzerk/boot_cljs_repl.clj
@@ -164,8 +164,8 @@
   [b ids BUILD_IDS  #{str} "Only inject reloading into these builds (= .cljs.edn files)"
    i ip ADDR        str "The IP address for the server to listen on."
    p port PORT      int "The port the websocket server listens on."
-   w ws-host WSADDR str  "The (optional) websocket host address to pass to clients."
-   s secure         bool  "(Optional) flag to indicate whether to connect via wss. Defaults to false."]
+   w ws-host WSADDR str "The (optional) websocket host address to pass to clients."
+   s secure         bool "Flag to indicate whether the client should connect via wss. Defaults to false."]
   (let [src (b/tmp-dir!)
         tmp (b/tmp-dir!)]
     (warn-deps-versions)


### PR DESCRIPTION
We're using these new options to proxy the REPL websocket through nginx in development. ws-host and secure are both supported by boot-reload.