### PR TITLE
Add nrepl opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[adzerk/boot-cljs-repl "0.2.0"] ;; latest release
+[adzerk/boot-cljs-repl "0.2.1-SNAPSHOT"] ;; latest release
 ```
 [](/dependency)
 

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 
 (require '[adzerk.bootlaces :refer :all])
 
-(def +version+ "0.2.0")
+(def +version+ "0.2.1-SNAPSHOT")
 
 (bootlaces! +version+)
 

--- a/src/adzerk/boot_cljs_repl.clj
+++ b/src/adzerk/boot_cljs_repl.clj
@@ -166,9 +166,12 @@
    p port PORT      int "The port the websocket server listens on."
    w ws-host WSADDR str "The (optional) websocket host address to pass to clients."
    s secure         bool "Flag to indicate whether the client should connect via wss. Defaults to false."]
+   n nrepl-opts NREPL_OPTS edn "Options passed to the `repl` task."
   (let [src (b/tmp-dir!)
         tmp (b/tmp-dir!)
-        prev (atom nil)]
+        prev (atom nil)
+        piggie-repl (partial repl :server true
+                             :middleware ['cemerick.piggieback/wrap-cljs-repl])]
     (b/set-env! :source-paths #(conj % (.getPath src))
                 :dependencies #(into % (vec (seq @deps))))
     (warn-deps-versions)
@@ -181,8 +184,9 @@
     (make-repl-connect-file nil)
     (util/dbug "Loaded REPL dependencies: %s\n" (pr-str (repl-deps)))
     (comp
-      (repl :server     true
-            :middleware ['cemerick.piggieback/wrap-cljs-repl])
+      (if nrepl-opts
+        (apply piggie-repl (mapcat identity nrepl-opts))
+        (piggie-repl))
       (b/with-pre-wrap fileset
         (doseq [f (relevant-cljs-edn @prev fileset ids)]
           (let [path     (b/tmp-path f)

--- a/src/adzerk/boot_cljs_repl.clj
+++ b/src/adzerk/boot_cljs_repl.clj
@@ -161,12 +161,12 @@
   The default configuration starts a websocket server on a random available
   port on localhost."
 
-  [b ids BUILD_IDS  #{str} "Only inject reloading into these builds (= .cljs.edn files)"
-   i ip ADDR        str "The IP address for the server to listen on."
-   p port PORT      int "The port the websocket server listens on."
-   w ws-host WSADDR str "The (optional) websocket host address to pass to clients."
-   s secure         bool "Flag to indicate whether the client should connect via wss. Defaults to false."]
+  [b ids BUILD_IDS         #{str} "Only inject reloading into these builds (= .cljs.edn files)"
+   i ip ADDR               str "The IP address for the server to listen on."
    n nrepl-opts NREPL_OPTS edn "Options passed to the `repl` task."
+   p port PORT             int "The port the websocket server listens on."
+   w ws-host WSADDR        str "The (optional) websocket host address to pass to clients."
+   s secure                bool "Flag to indicate whether the client should connect via wss. Defaults to false."]
   (let [src (b/tmp-dir!)
         tmp (b/tmp-dir!)
         prev (atom nil)


### PR DESCRIPTION
This allows for passing in options to the `repl` task started by `cljs-repl`. Fixes #30.