### PR TITLE
Default to both REPL and console printing

### DIFF
--- a/src/adzerk/boot_cljs_repl.clj
+++ b/src/adzerk/boot_cljs_repl.clj
@@ -48,7 +48,7 @@
             (:require [weasel.repl :as repl]))
           (let [repl-conn ~conn]
             (when (and repl-conn (not (repl/alive?)))
-              (repl/connect ~conn)))))
+              (repl/connect ~conn :print #{:repl :console})))))
        (map pr-str) (interpose "\n") (apply str) (spit @out-file)))
 
 (defn- write-repl-connect-file


### PR DESCRIPTION
Weasel by default overwrites the `*print-fn*` global variable to redirect all printing to the REPL after the REPL connection has been opened. In practice this means that if you are using boot-cljs-repl and are also printing to the console via `(enable-console-print)`, your console printing will work for an abritrary period of time until it doesn't anymore.

This patch configures Weasel to set the `*print-fn*` to print to the REPL and the console. IMO, this is the best default to ensure that users aren't confused when half their print statements stop working. It's not at all obvious that what the cause is and the amount of people that will be run into this problem is large.

I'm also open to exposing this as an option for the task, if you think that's a good idea.

Addresses this issue: https://github.com/adzerk-oss/boot-cljs-repl/issues/26