### PR TITLE
Bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # boot-cljs-repl
 
 ```clojure
-[adzerk/boot-cljs-repl   "0.3.0"] ;; latest release
+[adzerk/boot-cljs-repl   "0.3.2"] ;; latest release
 [com.cemerick/piggieback "0.2.1"  :scope "test"]
 [weasel                  "0.7.0"  :scope "test"]
 [org.clojure/tools.nrepl "0.2.12" :scope "test"]


### PR DESCRIPTION
Incorrect 0.3.0 version meant that cljs-repl-env wasn't found.