### PR TITLE
Add emphasis to `start-repl` line

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ boot repl -c
 ```
 
 ```clj
-boot.user=> (start-repl)
+boot.user=> (start-repl) ; Don't forget this step!
 ```
 
 #### Emacs Cider
@@ -75,7 +75,7 @@ M-x cider-connect
 ```
 
 ```clj
-boot.user=> (start-repl)
+boot.user=> (start-repl) ; Don't forget this step!
 ```
 
 ##### The `cljs-repl-env` task


### PR DESCRIPTION
It's actually really easy to miss the `start-repl` line, and once you get connected, the REPL looks like it's been brought up successfully.