### PR TITLE
Use cider/piggieback and nrepl new dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ```clojure
 [adzerk/boot-cljs-repl   "0.3.3"] ;; latest release
-[com.cemerick/piggieback "0.2.1"  :scope "test"]
+[cider/piggieback        "0.3.5"  :scope "test"]
 [weasel                  "0.7.0"  :scope "test"]
-[org.clojure/tools.nrepl "0.2.12" :scope "test"]
+[nrepl                   "0.3.1"  :scope "test"]
 ```
 
 [Boot] task providing a ClojureScript browser REPL via [Weasel] and [Piggieback].
@@ -180,4 +180,4 @@ your option) any later version.
 [Boot]: https://github.com/boot-clj/boot
 [Cider]: https://github.com/clojure-emacs/cider
 [Weasel]: https://github.com/tomjakubowski/weasel
-[piggieback]: https://github.com/cemerick/piggieback
+[piggieback]: https://github.com/nrepl/piggieback

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ```clojure
 [adzerk/boot-cljs-repl   "0.3.3"] ;; latest release
-[cider/piggieback        "0.3.5"  :scope "test"]
+[cider/piggieback        "0.3.9"  :scope "test"]
 [weasel                  "0.7.0"  :scope "test"]
-[nrepl                   "0.3.1"  :scope "test"]
+[nrepl                   "0.4.5"  :scope "test"]
 ```
 
 [Boot] task providing a ClojureScript browser REPL via [Weasel] and [Piggieback].

--- a/build.boot
+++ b/build.boot
@@ -1,8 +1,8 @@
 (set-env!
   :resource-paths #{"src"}
-  :dependencies '[[cider/piggieback "0.3.5" :scope "test"]
+  :dependencies '[[cider/piggieback "0.3.9" :scope "test"]
                   [weasel           "0.7.0" :scope "test"]
-                  [nrepl            "0.3.1" :scope "test"]])
+                  [nrepl            "0.4.5" :scope "test"]])
 
 (def +version+ "0.5.0-SNAPSHOT")
 

--- a/build.boot
+++ b/build.boot
@@ -1,10 +1,10 @@
 (set-env!
   :resource-paths #{"src"}
-  :dependencies '[[com.cemerick/piggieback "0.2.2" :scope "test"]
-                  [weasel                  "0.7.0" :scope "test"]
-                  [org.clojure/tools.nrepl "0.2.13" :scope "test"]])
+  :dependencies '[[cider/piggieback "0.3.5" :scope "test"]
+                  [weasel           "0.7.0" :scope "test"]
+                  [nrepl            "0.3.1" :scope "test"]])
 
-(def +version+ "0.4.0-SNAPSHOT")
+(def +version+ "0.5.0-SNAPSHOT")
 
 (task-options!
   pom  {:project     'adzerk/boot-cljs-repl

--- a/src/adzerk/boot_cljs_repl.clj
+++ b/src/adzerk/boot_cljs_repl.clj
@@ -16,9 +16,9 @@
 (def ^:private out-file (atom nil))
 
 (def ^:private deps
-  '[[com.cemerick/piggieback "0.2.2" :scope "test"]
-    [weasel                  "0.7.0" :scope "test"]
-    [org.clojure/tools.nrepl "0.2.13" :scope "test"]])
+  '[[cider/piggieback "0.3.5" :scope "test"]
+    [weasel           "0.7.0" :scope "test"]
+    [nrepl            "0.3.1" :scope "test"]])
 
 (defn- assert-deps
   "Advices user to add direct deps to requires deps if they
@@ -112,7 +112,7 @@
   :secure  bool  Flag to indicate whether to use a secure websocket.
   :cljs-repl-opts edn Repl options passed to the Piggieback client."
   [& {:keys [ip port secure ws-host cljs-repl-opts] :as opts}]
-  (apply (r cemerick.piggieback/cljs-repl) (apply repl-env (mapcat identity (dissoc opts :cljs-repl-opts)))
+  (apply (r cider.piggieback/cljs-repl) (apply repl-env (mapcat identity (dissoc opts :cljs-repl-opts)))
          (mapcat identity cljs-repl-opts)))
 
 (defn- add-init!

--- a/src/adzerk/boot_cljs_repl.clj
+++ b/src/adzerk/boot_cljs_repl.clj
@@ -16,9 +16,9 @@
 (def ^:private out-file (atom nil))
 
 (def ^:private deps
-  '[[cider/piggieback "0.3.5" :scope "test"]
+  '[[cider/piggieback "0.3.9" :scope "test"]
     [weasel           "0.7.0" :scope "test"]
-    [nrepl            "0.3.1" :scope "test"]])
+    [nrepl            "0.4.5" :scope "test"]])
 
 (defn- assert-deps
   "Advices user to add direct deps to requires deps if they
@@ -197,5 +197,5 @@
     ;; FIXME: concat :middleware?
     (apply repl (mapcat identity (merge nrepl-opts
                                         {:server true
-                                         :middleware ['cemerick.piggieback/wrap-cljs-repl]})))
+                                         :middleware ['cider.piggieback/wrap-cljs-repl]})))
     (apply cljs-repl-env (mapcat identity (dissoc *opts* :nrepl-opts)))))


### PR DESCRIPTION
Note that this is still not really usable because the `repl` boot task is still
tied to the old namespace. It is probably safer to wait for core to change
before merging and releasing this one.

The dep for `nrepl` is `0.3.1` for now, see https://github.com/nrepl/nREPL#status for details on what it means.